### PR TITLE
fix duplicated ranking in real contests (only)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -303,11 +303,12 @@ class Contest(models.Model):
 
         return running, coming, past
 
-    def group_names(self):
-        return list(
-            self.instances.order_by(Lower('group'))
-                .values_list('group', flat=True).distinct()
-        )
+    def group_names(self, include_virtual):
+        qs = self.instances
+        if not include_virtual:
+            qs = qs.filter(real=True)
+
+        return list(qs.order_by(Lower('group')).values_list('group', flat=True).distinct())
 
 
 class Problem(models.Model):

--- a/mog/views/contest.py
+++ b/mog/views/contest.py
@@ -273,7 +273,7 @@ def contest_standing(request, contest_id):
         # by default in virtual participation show all teams in one group
         group_names = [None]
     elif group_in_ranking == '<all>':
-        group_names = (contest.group_names() or [None])
+        group_names = (contest.group_names(include_virtual=show_virtual) or [None])
     elif group_in_ranking == '<one>':
         group_names = [None]
     else:
@@ -311,7 +311,7 @@ def contest_standing(request, contest_id):
         'ranking_groups': ranking_groups,
         'show_virtual': show_virtual,
         'user_instance': user_instance,
-        'group_names': contest.group_names(),
+        'group_names': contest.group_names(include_virtual=show_virtual),
         'group_in_ranking': group_in_ranking,
         'show_virtual_checkbox': show_virtual_checkbox
     })


### PR DESCRIPTION
We still have the duplicated issue for virtual participation but that will need a better solution. This is because virtual participants are registered using `None` as group and this group is the one that we internally use to render the whole ranking :(