### PR TITLE
fix markdown in edit problem

### DIFF
--- a/mog/views/problem.py
+++ b/mog/views/problem.py
@@ -144,7 +144,7 @@ class ProblemEditView(View):
         if not is_admin_or_judge_for_problem(request.user, problem):
             return HttpResponseForbidden()
 
-        form = ProblemForm(request.POST)
+        form = ProblemForm(request.POST, instance=problem)
         if not form.is_valid():
             return render(request, 'mog/problem/edit.html', {
                 'form': form, 'problem': problem,


### PR DESCRIPTION
If a problem failed the edit operation, then a new form is sent back. As this form wasn't bounded to any `problem` instance, it was assuming the legacy editor by adding `summernote-editor` instead of `markdown-editor` as CSS class. This cause some issues rendering the problem sections.