### PR TITLE
Fix OpenID related bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ chardet==3.0.4
 click==8.1.7
 colorama==0.3.9
 confusable-homoglyphs==3.2.0
-defusedxml==0.5.0
+defusedxml==0.6.0
 Django==2.0
 django-debug-toolbar==1.9.1
 django-ranged-response==0.2.0


### PR DESCRIPTION
See this: https://stackoverflow.com/questions/62776611/typeerror-not-enough-arguments-for-format-string-in-django-social-login
>  Python 3.8 broke features of defusexml 0.5.0. Instead of downgrading python from 3.8 to 3.6, you can upgrade defusexml to 0.6.0. The issue was fixed here.
