### PR TITLE
Fix possible error when sandbox dir (or parent) does not exists

### DIFF
--- a/api/management/commands/grader.py
+++ b/api/management/commands/grader.py
@@ -59,7 +59,7 @@ def remove_submission_folder(submission):
 
 def create_submission_folder(submission):
     submission_folder = remove_submission_folder(submission)
-    os.mkdir(submission_folder)
+    os.makedirs(submission_folder, exist_ok=True)
     return submission_folder
 
 


### PR DESCRIPTION
It just instead of creating the leaf dir, it creates the missing parent dirs if necessary and then the leaf. E.g:
`/some/path/to/sandbox`
It will create if necessary `/some`, then `/some/path`, then `/some/path/to` and then `/some/path/to/sandbox`

Previously if `/some/path/to` did not exist it would raise an exception and kill the grader
