### PR TITLE
Configure Iptables to only allow exit network connections from root processes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,11 @@ services:
     build:
       context: .
       dockerfile: dockerfile.grader
-    command: /code/environ/bin/python3 manage.py grader --number_of_executions 1
+    command: bash -c "bash grader-firewall.sh && /code/environ/bin/python3 manage.py grader --number_of_executions 1"
     volumes:
       - judge-problems:/problems
+    cap_add:
+      - NET_ADMIN
 
 volumes:
   django-media:

--- a/dockerfile.grader
+++ b/dockerfile.grader
@@ -2,7 +2,7 @@ FROM alpine:3.15.0
 
 # Update the system, and add bash and the glibc compatibility
 # layer, plus git python gcc and java
-RUN apk update && apk upgrade && apk add bash gcompat postgresql-dev git python3 python3-dev gcc g++ openjdk17-jdk
+RUN apk update && apk upgrade && apk add bash gcompat postgresql-dev git python3 python3-dev gcc g++ openjdk17-jdk iptables
 
 # Copy project content in the host machine into the container
 # as /code folder.

--- a/grader-firewall.sh
+++ b/grader-firewall.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+iptables -F
+iptables -A OUTPUT -m owner --uid-owner 0 -j ACCEPT
+iptables -A OUTPUT -j DROP


### PR DESCRIPTION
In order to avoid some security issues we must deny outgoing connections from unprivileged users/processes

This solves #113
