### PR TITLE
Use the flags specified by ICPC for Java and Kotlin

### DIFF
--- a/api/management/commands/grader.py
+++ b/api/management/commands/grader.py
@@ -193,9 +193,9 @@ def get_cmd_for_language_safeexec(
     #    escalation/Information diclosure) all because it uses the SUID bit
     # note3:Shall we consider only CPU seconds and ignore the delay caused by the syscalls?
     if lang == "java":
-        return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /usr/bin/java -Xms32M -Xmx{memory_limit*1024}M -Xss64m -DMOG=true Main"
+        return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /usr/bin/java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xms32m -Xmx{memory_limit*1024}M -Xss64m -DMOG=true Main"
     elif lang == "kotlin":
-        return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /usr/bin/java -Xms32M -Xmx{memory_limit*1024}M -Xss64m -DMOG=true MainKt"
+        return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /opt/kotlin-1.7.21/bin/kotlin -Dfile.encoding=UTF-8 -J-XX:+UseSerialGC -J-Xms32M -J-Xmx{memory_limit*1024}M -J-Xss64m -J-DMOG=true MainKt"
     elif lang in ["python", "javascript", "python2", "python3"]:
         fmt_args = compiler.arguments.format(
             "%d.%s" % (submission.id, compiler.file_extension)


### PR DESCRIPTION

Refer to: https://docs.icpc.global/worldfinals-programming-environment/
