### PR TITLE
Add Mono Compiler

### DIFF
--- a/api/management/commands/grader.py
+++ b/api/management/commands/grader.py
@@ -196,6 +196,8 @@ def get_cmd_for_language_safeexec(
         return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /usr/bin/java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xms32m -Xmx{memory_limit*1024}M -Xss64m -DMOG=true Main"
     elif lang == "kotlin":
         return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /opt/kotlin-1.7.21/bin/kotlin -Dfile.encoding=UTF-8 -J-XX:+UseSerialGC -J-Xms32M -J-Xmx{memory_limit*1024}M -J-Xss64m -J-DMOG=true MainKt"
+    elif lang=="csharp":
+        return f"safeexec --nproc 6 --mem {memory_limit*1024} --cpu {time_limit} --exec /usr/local/bin/mono ./{submission.id}.{compiler.exec_extension}"
     elif lang in ["python", "javascript", "python2", "python3"]:
         fmt_args = compiler.arguments.format(
             "%d.%s" % (submission.id, compiler.file_extension)

--- a/ci/fix_mono.sh
+++ b/ci/fix_mono.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Seems like the musl version in alpine:3.15.0 is missing the symbol pthread_getname_np
+# It is solved by upgrading to alpine:3.16.0, but that will break dependencies that rely on
+# python 3.9, so this simple program solves the issue:
+
+function gen_wrapper() {
+	name=$1
+	cat << END
+#!/bin/sh
+export LD_PRELOAD=/fixmono.so
+$name \$*
+END
+}
+
+
+cat > /tmp/pthread_getname_np.c << EOF
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/prctl.h>
+#include <pthread.h>
+#include <errno.h>
+
+int pthread_getname_np(pthread_t thread, char *name, size_t len)
+{
+        int fd, cs, status = 0;
+        char f[sizeof "/proc/self/task//comm" + 3*sizeof(int)];
+
+        if (len > 15) return ERANGE;
+
+        if (thread == pthread_self())
+                return prctl(PR_GET_NAME, name) ? errno : 0;
+
+        snprintf(f, sizeof f, "/proc/self/task/%d/comm", (pid_t)thread);
+        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+        if ((fd = open(f, O_RDONLY)) < 0 || read(fd, name, len) < 0) status = errno;
+        if (fd >= 0) close(fd);
+        pthread_setcancelstate(cs, 0);
+        return status;
+}
+
+EOF
+
+# Compile and save
+gcc -shared /tmp/pthread_getname_np.c -o /fixmono.so
+
+# Generate the wrapper script(s)
+gen_wrapper /usr/bin/csc > /usr/local/bin/csc
+gen_wrapper /usr/bin/mono > /usr/local/bin/mono
+chmod +x /usr/local/bin/csc
+chmod +x /usr/local/bin/mono

--- a/dockerfile.grader
+++ b/dockerfile.grader
@@ -51,4 +51,6 @@ RUN cd /opt && \
 	mv kotlinc kotlin-1.7.21
 
 # 14. Install the C# tools
-RUN apk add mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
+# 15. Compile and save the fix to the bug described in ci/fix_mono.sh
+RUN apk add mono --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing && \
+	bash ci/fix_mono.sh


### PR DESCRIPTION
Its pretty straightforward: to install just need to use temporarily the testing repos and install the `mono` package.

But seems like the version of mono uses a symbol not available in this version of alpine, so we must either:
* Bump the image version: *will* break dependencies.
* Define the symbol ourselves: just define the symbol in a C file (borrowed from a musl repo), compile it and use the LD_PRELOAD trick to link dynamically our binary before musl

To specify in the compiler section:
* language: `csharp`
* path: `/usr/local/bin/csc`
* args: `{0}` (pass the source file)
* other options are either optional or can use any value
