### PR TITLE
filter submissions by language, not compiler

### DIFF
--- a/api/management/commands/grader.py
+++ b/api/management/commands/grader.py
@@ -196,7 +196,7 @@ def get_cmd_for_language_safeexec(
         return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /usr/bin/java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xms32m -Xmx{memory_limit*1024}M -Xss64m -DMOG=true Main"
     elif lang == "kotlin":
         return f"safeexec --nproc 20 --mem {memory_limit*1024} --cpu {time_limit} --exec /opt/kotlin-1.7.21/bin/kotlin -Dfile.encoding=UTF-8 -J-XX:+UseSerialGC -J-Xms32M -J-Xmx{memory_limit*1024}M -J-Xss64m -J-DMOG=true MainKt"
-    elif lang=="csharp":
+    elif lang == "csharp":
         return f"safeexec --nproc 6 --mem {memory_limit*1024} --cpu {time_limit} --exec /usr/local/bin/mono ./{submission.id}.{compiler.exec_extension}"
     elif lang in ["python", "javascript", "python2", "python3"]:
         fmt_args = compiler.arguments.format(

--- a/api/migrations/0047_compiler_active.py
+++ b/api/migrations/0047_compiler_active.py
@@ -4,15 +4,14 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('api', '0046_auto_20240929_1518'),
+        ("api", "0046_auto_20240929_1518"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='compiler',
-            name='active',
+            model_name="compiler",
+            name="active",
             field=models.BooleanField(default=True),
         ),
     ]

--- a/api/models.py
+++ b/api/models.py
@@ -693,8 +693,8 @@ class Compiler(models.Model):
         return self.name
 
     @staticmethod
-    def get_all_compilers():
-        return Compiler.objects.order_by("name").all()
+    def get_all_languages():
+        return sorted(Compiler.objects.values_list("language", flat=True).distinct())
 
 
 ROLE_CHOICES = [

--- a/mog/helpers.py
+++ b/mog/helpers.py
@@ -26,7 +26,7 @@ def filter_submissions(
     contest=None,
     username=None,
     result=None,
-    compiler=None,
+    language=None,
     problem_exact=False,
     **kwargs
 ):
@@ -96,12 +96,9 @@ def filter_submissions(
     except (Result.DoesNotExist, ValueError):
         result = None
 
-    try:
-        compiler = Compiler.objects.get(pk=compiler)
-        queryset = queryset.filter(compiler=compiler)
-        query["compiler"] = str(compiler.pk)  # encode back
-    except (Compiler.DoesNotExist, ValueError):
-        compiler = None
+    if language:
+        queryset = queryset.filter(compiler__language=language)
+        query["language"] = language  # encode back
 
     return queryset.order_by("-pk"), query
 

--- a/mog/templates/mog/contest/submissions.html
+++ b/mog/templates/mog/contest/submissions.html
@@ -34,11 +34,11 @@
                                 {% if query.result|inteq:result.id %}selected{% endif %}>{{ result.name }}</option>
                     {% endfor %}
                 </select>
-                <select id="compiler" name="compiler" class="form-control">
-                    <option value="" selected>-- Select compiler --</option>
-                    {% for compiler in compilers %}
-                        <option value="{{ compiler.id }}"
-                                {% if query.compiler|inteq:compiler.id %}selected{% endif %}>{{ compiler.name }}</option>
+                <select id="language" name="language" class="form-control">
+                    <option value="" selected>{% trans '-- Select language --' %}</option>
+                    {% for language in languages %}
+                        <option value="{{ language }}"
+                                {% if query.language == language %}selected{% endif %}>{{ language }}</option>
                     {% endfor %}
                 </select>
                 <button type="submit" class="btn btn-default">{% trans 'Filter' %}</button>

--- a/mog/templates/mog/submission/index.html
+++ b/mog/templates/mog/submission/index.html
@@ -26,16 +26,15 @@
                                 {% if query.result|inteq:result.id %}selected{% endif %}>{{ result.name }}</option>
                     {% endfor %}
                 </select>
-                <select id="compiler" name="compiler" class="form-control">
-                    <option value="" selected>{% trans '-- Select compiler --' %}</option>
-                    {% for compiler in compilers %}
-                        <option value="{{ compiler.id }}"
-                                {% if query.compiler|inteq:compiler.id %}selected{% endif %}>{{ compiler.name }}</option>
+                <select id="language" name="language" class="form-control">
+                    <option value="" selected>{% trans '-- Select language --' %}</option>
+                    {% for language in languages %}
+                        <option value="{{ language }}"
+                                {% if query.language == language %}selected{% endif %}>{{ language }}</option>
                     {% endfor %}
                 </select>
                 <button type="submit" class="btn btn-default">{% trans 'Filter' %}</button>
             </form>
-
             <hr/>
         </div>
 

--- a/mog/views/contest.py
+++ b/mog/views/contest.py
@@ -391,16 +391,9 @@ def contest_submissions(request, contest_id):
         contest=contest.id,
         username=request.GET.get("username"),
         result=request.GET.get("result"),
-        compiler=request.GET.get("compiler"),
+        language=request.GET.get("language"),
     )
     submissions = get_paginator(submission_list, 30, request.GET.get("page"))
-    compilers_id = list(
-        {
-            compiler_id["compilers"]
-            for compiler_id in list(contest.problems.values("compilers"))
-        }
-    )
-    compilers = Compiler.objects.filter(pk__in=compilers_id).order_by("name")
     return render(
         request,
         "mog/contest/submissions.html",
@@ -408,7 +401,7 @@ def contest_submissions(request, contest_id):
             "contest": contest,
             "submissions": submissions,
             "results": Result.get_all_results(),
-            "compilers": compilers,
+            "languages": Compiler.get_all_languages(),
             "query": query,
         },
     )

--- a/mog/views/submission.py
+++ b/mog/views/submission.py
@@ -29,7 +29,7 @@ def submissions(request):
         contest=request.GET.get("contest"),
         username=request.GET.get("username"),
         result=request.GET.get("result"),
-        compiler=request.GET.get("compiler"),
+        language=request.GET.get("language"),
     )
     submissions = get_paginator(submission_list, 30, request.GET.get("page"))
     return render(
@@ -38,7 +38,7 @@ def submissions(request):
         {
             "submissions": submissions,
             "results": Result.get_all_results(),
-            "compilers": Compiler.get_all_compilers(),
+            "languages": Compiler.get_all_languages(),
             "query": query,
         },
     )


### PR DESCRIPTION
To simplify the submissions filter, this change lists only
languages instead of specific compilers. As MOG adds
more compilers, this prevents clutter in the dropdown.

### Before
<img width="888" alt="image" src="https://github.com/user-attachments/assets/c4550bbc-c363-4d17-95f4-0815bcf207c1" />

### After
<img width="890" alt="image" src="https://github.com/user-attachments/assets/c6fd8b7e-ecaa-409f-8da6-87bf495d208f" />
