### PR TITLE
[bandaid] temporary solution to expose active compilers

### DIFF
--- a/mog/templates/mog/submit/submit.html
+++ b/mog/templates/mog/submit/submit.html
@@ -112,7 +112,7 @@
         var compilersPerProblem = {};
         {% for problem_ in problem.contest.problems.all %}
             compilersPerProblem[{{ problem_.id }}] = [];
-            {% for compiler in problem_.compilers.all %}
+            {% for compiler in compilers %}
                 compilersPerProblem[{{ problem_.id }}].push({{ compiler.id }});
             {% endfor %}
             compilersPerProblem[{{ problem_.id }}].sort(function(a, b) {

--- a/mog/views/submission.py
+++ b/mog/views/submission.py
@@ -88,7 +88,7 @@ class Submit(View):
             "mog/submit/submit.html",
             {
                 "problem": problem,
-                "compilers": Compiler.objects.order_by("id"),
+                "compilers": Compiler.objects.filter(active=True).order_by("id"),
             },
         )
 
@@ -132,7 +132,6 @@ class Submit(View):
         if (
             not user_is_admin(request.user)
             and not user_is_judge_in_contest(request.user, problem.contest)
-            and compiler not in problem.compilers.all()
         ):
             msg = _("Invalid language choice")
             messages.warning(request, msg, extra_tags="danger")


### PR DESCRIPTION
I’m not a fan of this approach, but it's a quick
way to ensure only active compilers are exposed. A
full refactor is needed, but without this step, users
will face a suboptimal experience.