### PR TITLE
[django social] add https to redirect URI

### DIFF
--- a/judge/settings.py
+++ b/judge/settings.py
@@ -307,6 +307,7 @@ if DEBUG and DEBUG_TOOLBAR:
     INTERNAL_IPS = ["127.0.0.1"]
 
 # Social settings
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
 # --> facebook
 SOCIAL_AUTH_FACEBOOK_KEY = config.get("social", "SOCIAL_AUTH_FACEBOOK_KEY")


### PR DESCRIPTION
We're redirecting to an HTTP URL during login,
causing authentication to fail for Google and
GitHub. This PR forces Django Social to use HTTPS
in the redirect URI.