### PR TITLE
[fix] do not force compiler to be in problem's compiler list

### DIFF
--- a/mog/views/submission.py
+++ b/mog/views/submission.py
@@ -128,14 +128,18 @@ class Submit(View):
             )
             messages.warning(request, msg, extra_tags="danger")
             return redirect("mog:submit", problem.id)
+        
 
-        if (
-            not user_is_admin(request.user)
-            and not user_is_judge_in_contest(request.user, problem.contest)
-        ):
-            msg = _("Invalid language choice")
-            messages.warning(request, msg, extra_tags="danger")
-            return redirect("mog:submit", problem.id)
+        # TODO(lcastillov): We're temporarily bypassing the list of compilers in a problem
+        # until we can get both active and inactive compilers working together properly.
+        # if (
+        #     not user_is_admin(request.user)
+        #     and not user_is_judge_in_contest(request.user, problem.contest)
+        #     and compiler not in problem.compilers.all()
+        # ):
+        #     msg = _("Invalid language choice")
+        #     messages.warning(request, msg, extra_tags="danger")
+        #     return redirect("mog:submit", problem.id)
 
         if file is not None:
             source = file.read().decode("utf8")


### PR DESCRIPTION
This is a temporary change to ensure everyone can submit in any active language without worrying about assigned compilers. We need to revisit this later to make active and inactive compilers work smoothly together. But for now, to unblock people from testing the new grader, we won't enforce this.