### PR TITLE
bugfix: captcha

### DIFF
--- a/docker/dev/dockerfile
+++ b/docker/dev/dockerfile
@@ -5,6 +5,9 @@ FROM alpine:3.15.0
 # postgresql development files, gcc (required for pip dependencies, removed later), musl development files (header files required)
 RUN apk upgrade && apk add bash gcompat python3 python3-dev jpeg-dev zlib-dev postgresql-dev gcc musl-dev gettext
 
+# To make `django-simple-captcha` work correctly, install Pillow with FreeType support.
+RUN apk add freetype
+
 # Copy project content in the host machine into the container
 # as /code folder.
 WORKDIR /code

--- a/docker/prod/dockerfile
+++ b/docker/prod/dockerfile
@@ -5,6 +5,9 @@ FROM alpine:3.15.0
 # postgresql development files, gcc (required for pip dependencies, removed later), musl development files (header files required)
 RUN apk upgrade && apk add bash gcompat python3 python3-dev jpeg-dev zlib-dev postgresql-dev gcc musl-dev gettext
 
+# To make `django-simple-captcha` work correctly, install Pillow with FreeType support.
+RUN apk add freetype
+
 # Copy project content in the host machine into the container
 # as /code folder.
 WORKDIR /code

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ mypy-extensions==1.0.0
 oauthlib==2.0.6
 packaging==23.1
 pathspec==0.11.2
-Pillow==5.0.0
+Pillow==9.5.0
 platformdirs==3.10.0
 psycopg2==2.8.3
 pycodestyle==2.9.1


### PR DESCRIPTION
I had to install `freetype` and set Pillow to
version 9.5.0 to make it work.

**Currently in production**
<img width="356" alt="image" src="https://github.com/user-attachments/assets/2a700196-14b1-4c20-b12c-9e8e7abce427" />

**After the fix**
<img width="349" alt="image" src="https://github.com/user-attachments/assets/eb04eeaf-964a-4ba4-90df-640893090bf8" />
