### PR TITLE
export gunicorn metrics via statsd-exporter

### DIFF
--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: ../..
       dockerfile: docker/prod/dockerfile
-    command: environ/bin/gunicorn --workers 4 -b :8000 judge.wsgi:application
+    command: environ/bin/gunicorn --workers 4 --statsd-host=statsd_exporter:9125 --statsd-prefix=judge -b :8000 judge.wsgi:application
     volumes:
       - varwww:/var/www/judge
       - problems:/problems
@@ -90,6 +90,9 @@ services:
     restart: unless-stopped
     volumes:
       - '/:/host:ro,rslave'
+  statsd_exporter:
+    image: prom/statsd-exporter
+
 
 volumes:
   grafana:

--- a/docker/prod/prometheus.yml
+++ b/docker/prod/prometheus.yml
@@ -11,3 +11,6 @@ scrape_configs:
   - job_name: node
     static_configs:
       - targets: ["host.docker.internal:9100"]
+  - job_name: gunicorn
+    static_configs:
+      - targets: ["statsd_exporter:9102"]


### PR DESCRIPTION
It's nice to have this for running performance
tests and setting alerts for errors.