### PR TITLE
allow institution deletion

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: django\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-19 08:21+0000\n"
+"POT-Creation-Date: 2025-09-20 07:01+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -205,6 +205,7 @@ msgstr "Inicio"
 
 #: mog/templates/mog/base.html:162 mog/templates/mog/contest/permission.html:62
 #: mog/templates/mog/contest/registration.html:48
+#: mog/templates/mog/institution/index.html:22
 #: mog/templates/mog/user/index.html:12
 msgid "Users"
 msgstr "Usuarios"
@@ -284,6 +285,7 @@ msgstr "Patrocinado por"
 
 #: mog/templates/mog/checker/_actions.html:12
 #: mog/templates/mog/contest/_actions.html:12
+#: mog/templates/mog/institution/index.html:24
 #: mog/templates/mog/user/teams.html:19
 msgid "Actions"
 msgstr "Acciones"
@@ -300,7 +302,8 @@ msgstr "Contenido"
 #: mog/templates/mog/comment/_edit_comment.html:25
 #: mog/templates/mog/comment/_remove_comment.html:23
 #: mog/templates/mog/contest/_left.html:306
-#: mog/templates/mog/institution/index.html:86
+#: mog/templates/mog/institution/index.html:91
+#: mog/templates/mog/institution/index.html:138
 #: mog/templates/mog/problem/edit.html:28
 #: mog/templates/mog/user/_create_team.html:51
 #: mog/templates/mog/user/_edit_team.html:45
@@ -355,6 +358,7 @@ msgstr "Registro"
 #: mog/templates/mog/contest/_running_contests.html:14
 #: mog/templates/mog/contest/overview.html:88
 #: mog/templates/mog/contest/registration.html:77
+#: mog/templates/mog/institution/index.html:23
 #: mog/templates/mog/user/detail.html:20 mog/templates/mog/user/profile.html:57
 msgid "Teams"
 msgstr "Equipos"
@@ -961,31 +965,51 @@ msgid "Create institution"
 msgstr "Crear institución"
 
 #: mog/templates/mog/institution/index.html:19
-#: mog/templates/mog/institution/index.html:68
+#: mog/templates/mog/institution/index.html:120
 #: mog/templates/mog/user/_create_team.html:22
 #: mog/templates/mog/user/_edit_team.html:21
 msgid "Name"
 msgstr "Nombre"
 
 #: mog/templates/mog/institution/index.html:20
-#: mog/templates/mog/institution/index.html:72
+#: mog/templates/mog/institution/index.html:124
 msgid "Website"
 msgstr "Sitio web"
 
 #: mog/templates/mog/institution/index.html:21
-#: mog/templates/mog/institution/index.html:76
+#: mog/templates/mog/institution/index.html:128
 msgid "Country"
 msgstr "País"
 
-#: mog/templates/mog/institution/index.html:50
+#: mog/templates/mog/institution/index.html:57
+msgid "Cannot delete institution with users or teams"
+msgstr "No se puede eliminar institución con usuarios o equipos"
+
+#: mog/templates/mog/institution/index.html:62
+msgid "Delete institution"
+msgstr "Eliminar institución"
+
+#: mog/templates/mog/institution/index.html:77
+msgid "Delete Institution"
+msgstr "Eliminar Institución"
+
+#: mog/templates/mog/institution/index.html:81
+msgid "Are you sure you want to delete the institution"
+msgstr "¿Estás seguro que deseas eliminar la institución"
+
+#: mog/templates/mog/institution/index.html:92
+msgid "Delete"
+msgstr "Eliminar"
+
+#: mog/templates/mog/institution/index.html:102
 msgid "No institutions to show!"
 msgstr "¡No hay instituciones para mostrar!"
 
-#: mog/templates/mog/institution/index.html:64
+#: mog/templates/mog/institution/index.html:116
 msgid "Create Institution"
 msgstr "Crear Institución"
 
-#: mog/templates/mog/institution/index.html:87
+#: mog/templates/mog/institution/index.html:139
 msgid "Create"
 msgstr "Crear"
 
@@ -1672,21 +1696,39 @@ msgstr "Se eliminó el registro satisfactoriamente!"
 msgid "Error enabling this user/team: "
 msgstr ""
 
-#: mog/views/institution.py:58
+#: mog/views/institution.py:66
 msgid "Name is required"
 msgstr "Nombre es requerido"
 
-#: mog/views/institution.py:66
+#: mog/views/institution.py:74
 msgid "Invalid country"
 msgstr "País inválido"
 
-#: mog/views/institution.py:74
+#: mog/views/institution.py:82
 msgid "Error creating institution: "
 msgstr "Error creando institución: "
 
-#: mog/views/institution.py:78
+#: mog/views/institution.py:86
 msgid "Institution created"
 msgstr "Institución creada"
+
+#: mog/views/institution.py:97
+msgid "Institution not found"
+msgstr "Institución no encontrada"
+
+#: mog/views/institution.py:107
+msgid "Cannot delete institution with users or teams. Users: {}, Teams: {}"
+msgstr ""
+"No se puede eliminar institución con usuarios o equipos. Usuarios: {}, "
+"Equipos: {}"
+
+#: mog/views/institution.py:114
+msgid "Institution deleted successfully"
+msgstr "Institución eliminada exitosamente"
+
+#: mog/views/institution.py:116
+msgid "Error deleting institution: "
+msgstr "Error eliminando institución: "
 
 #: mog/views/submission.py:127
 msgid ""
@@ -1722,6 +1764,9 @@ msgstr ""
 #: mog/views/submission.py:250
 msgid "Cannot rejudge submission: It is currently in grading process."
 msgstr ""
+
+#~ msgid "This action cannot be undone."
+#~ msgstr "Esta acción no se puede deshacer."
 
 #~ msgid "Faculty of Mathematics and Computer Science of University of Havana"
 #~ msgstr "Facultad de Matemática Computación de La Universidad de La Habana"
@@ -1764,9 +1809,6 @@ msgstr ""
 
 #~ msgid "IP address"
 #~ msgstr "Dirección IP"
-
-#~ msgid "Delete"
-#~ msgstr "Eliminar"
 
 #~ msgid "or"
 #~ msgstr "o"

--- a/mog/templates/mog/institution/index.html
+++ b/mog/templates/mog/institution/index.html
@@ -15,52 +15,125 @@
     <table class="table table-bordered table-striped">
       <thead>
         <tr>
-          <th class="cell-small"><div class="center">#</div></th>
+          <th class="cell-small">
+            <div class="center">#</div>
+          </th>
           <th>{% trans 'Name' %}</th>
           <th>{% trans 'Website' %}</th>
-          <th class="cell-medium"><div class="center">{% trans 'Country' %}</div></th>
+          <th class="cell-medium">
+            <div class="center">{% trans 'Country' %}</div>
+          </th>
+          <th class="cell-small">
+            <div class="center">{% trans 'Users' %}</div>
+          </th>
+          <th class="cell-small">
+            <div class="center">{% trans 'Teams' %}</div>
+          </th>
+          <th class="cell-small">
+            <div class="center">{% trans 'Actions' %}</div>
+          </th>
         </tr>
       </thead>
       <tbody>
         {% for inst in institutions %}
         <tr>
-          <td><div class="center">{{ forloop.counter }}</div></td>
+          <td>
+            <div class="center">{{ forloop.counter }}</div>
+          </td>
           <td>{{ inst.name }}</td>
           <td>
             {% if inst.url %}
-              <a href="{{ inst.url }}" target="_blank" rel="noopener">{{ inst.url }}</a>
+            <a href="{{ inst.url }}" target="_blank" rel="noopener">{{ inst.url }}</a>
             {% else %}
-              —
+            —
             {% endif %}
           </td>
           <td>
             <div class="center">
               {% if inst.country %}
-                <img src="{{ inst.country.flag }}" alt="{{ inst.country.name }}"
-                     title="{{ inst.country.name }}" data-toggle="tooltip"
-                     style="height:16px; width:auto;" />
+              <img src="{{ inst.country.flag }}" alt="{{ inst.country.name }}" title="{{ inst.country.name }}"
+                data-toggle="tooltip" style="height:16px; width:auto;" />
               {% else %}
-                —
+              —
+              {% endif %}
+            </div>
+          </td>
+          <td>
+            <div class="center">{{ inst.user_count }}</div>
+          </td>
+          <td>
+            <div class="center">{{ inst.team_count }}</div>
+          </td>
+          <td>
+            <div class="center">
+              {% if inst.user_count > 0 or inst.team_count > 0 %}
+              <a href="#" class="text-muted" disabled data-toggle="tooltip"
+                title="{% trans 'Cannot delete institution with users or teams' %}"
+                style="padding: 2px 6px; font-size: 10px; cursor: not-allowed;">
+                <i class="glyphicon glyphicon-trash"></i>
+              </a>
+              {% else %}
+              <a href="#" data-toggle="modal" data-target="#remove-institution-{{ inst.id }}" class="text-danger"
+                data-toggle="tooltip" title="{% trans 'Delete institution' %}"
+                style="padding: 2px 6px; font-size: 10px;">
+                <i class="glyphicon glyphicon-trash"></i>
+              </a>
               {% endif %}
             </div>
           </td>
         </tr>
+
+        {% if inst.user_count == 0 and inst.team_count == 0 %}
+        <!-- Delete Confirmation Modal for {{ inst.name }} -->
+        <div class="modal fade" id="remove-institution-{{ inst.id }}" tabindex="-1" role="dialog"
+          aria-labelledby="myModalLabel">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                    aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="myModalLabel">{% trans 'Delete Institution' %}</h4>
+              </div>
+              <div class="modal-body">
+                <p class="text-justify">
+                  {% trans 'Are you sure you want to delete the institution' %} <strong>{{ inst.name }}</strong>?
+                </p>
+                <p class="text-center">
+                  <span class="glyphicon glyphicon-warning-sign"
+                    style="color: orange; font-size: 50px; font-weight: normal;"></span>
+                </p>
+              </div>
+              <div class="modal-footer">
+                <form action="{% url 'mog:institution_delete' inst.id %}" method="post">
+                  {% csrf_token %}
+                  <input type="hidden" name="_method" value="DELETE">
+                  <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
+                  <button type="submit" class="btn btn-danger">{% trans 'Delete' %}</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+        {% endif %}
+
         {% empty %}
         <tr>
-          <td colspan="4">{% trans 'No institutions to show!' %}</td>
+          <td colspan="7">{% trans 'No institutions to show!' %}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
 
-  <div class="modal fade" id="createInstitutionModal" tabindex="-1" role="dialog" aria-labelledby="createInstitutionLabel">
+  <div class="modal fade" id="createInstitutionModal" tabindex="-1" role="dialog"
+    aria-labelledby="createInstitutionLabel">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <form action="{% url 'mog:institutions' %}" method="post">
           {% csrf_token %}
           <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                aria-hidden="true">&times;</span></button>
             <h4 class="modal-title" id="createInstitutionLabel">{% trans 'Create Institution' %}</h4>
           </div>
           <div class="modal-body">
@@ -91,6 +164,5 @@
     </div>
   </div>
 </div>
+
 {% endblock %}
-
-

--- a/mog/urls.py
+++ b/mog/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
         name="institutions",
     ),
     url(
+        r"^institution/delete/(?P<institution_id>[0-9]+)/$",
+        views.InstitutionListView.as_view(),
+        name="institution_delete",
+    ),
+    url(
         r"^api/instance/group/list/$",
         views.instance_group_list,
         name="api_instance_group_list",


### PR DESCRIPTION
Add more information to the institutions table,
including the number of users and teams linked to
each institution, and allow deletion. For now,
deletion is only allowed for institutions with no
associations to ensure some safety.