### PR TITLE
move webhooks to settings.ini

### DIFF
--- a/judge/settings.py
+++ b/judge/settings.py
@@ -336,3 +336,11 @@ CACHES = {
         "LOCATION": "mog-cache",
     }
 }
+
+# This section lists Discord webhooks for sending clarifications, one URL per line
+DISCORD_CLARIFICATION_WEBHOOKS = []
+if config.has_section("webhooks.clarifications"):
+    DISCORD_CLARIFICATION_WEBHOOKS = config.get(
+        "webhooks.clarifications", "DISCORD"
+    ).split("\n")
+    DISCORD_CLARIFICATION_WEBHOOKS = list(filter(None, DISCORD_CLARIFICATION_WEBHOOKS))

--- a/mog/webhooks.py
+++ b/mog/webhooks.py
@@ -1,16 +1,12 @@
 import requests
-
-WEBHOOKS = [
-    "https://discordapp.com/api/webhooks/619074191571812352/GurZA2CioYYZsaHktiiWwnaOFlbt2rCYybpHD9TCB7loKEwzl0H8wc0y_zbuAk40mf6c",  # Discord MOG
-    "https://discordapp.com/api/webhooks/619077907956105236/PAyrQ_HllSxm2Har9HvRCS5PnapfYK0jJs3UQXwrGouq6fedP1fpWfeB1tUoUjn28RwY",  # Discord ICPC Caribe
-]
+from django.conf import settings
 
 
 def post_content(content):
     payload = {"embeds": [content]}
 
     with requests.Session() as sess:
-        for webhook in WEBHOOKS:
+        for webhook in settings.DISCORD_CLARIFICATION_WEBHOOKS:
             sess.post(webhook, json=payload)
 
 


### PR DESCRIPTION
We shouldn't hardcode these URLs. Let's move them
to the configuration file (settings.ini) for better flexibility and security.