### PR TITLE
truncate very long samples

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: django\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-20 07:01+0000\n"
+"POT-Creation-Date: 2025-09-28 19:31+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,30 +26,30 @@ msgid ""
 "Markdown Editor."
 msgstr ""
 
-#: api/models.py:766
+#: api/models.py:767
 msgid "Code Editor Theme"
 msgstr "Tema del editor de código"
 
-#: api/models.py:772
+#: api/models.py:773
 msgid "Avatar"
 msgstr "Imagen"
 
-#: api/models.py:774
+#: api/models.py:775
 msgid "Show tags"
 msgstr "Mostrar etiquetas"
 
-#: api/models.py:776
+#: api/models.py:780
 #: mog/templates/mog/contest/_edit_instance_team_modal.html:32
 #: mog/templates/mog/user/_create_team.html:32
 #: mog/templates/mog/user/_edit_team.html:31
 msgid "Institution"
 msgstr "Institución"
 
-#: api/models.py:781 mog/templates/mog/submit/submit.html:55
+#: api/models.py:789 mog/templates/mog/submit/submit.html:55
 msgid "Compiler"
 msgstr "Compilador"
 
-#: api/models.py:784 mog/templates/mog/base.html:271
+#: api/models.py:793 mog/templates/mog/base.html:271
 #: mog/templates/mog/problem/index.html:37
 #: mog/templates/mog/problem/index.html:39
 #: mog/templates/mog/problem/index.html:41
@@ -57,15 +57,15 @@ msgstr "Compilador"
 msgid "Points"
 msgstr "Puntos"
 
-#: api/models.py:787
+#: api/models.py:796
 msgid "Send email notifications"
 msgstr "Enviar notificaciones por correo"
 
-#: api/models.py:1123
+#: api/models.py:1132
 msgid "Group name"
 msgstr "Nombre del grupo"
 
-#: api/models.py:1128
+#: api/models.py:1137
 msgid ""
 "If true, render the team without members and only displaying the description "
 "on hover"
@@ -73,46 +73,46 @@ msgstr ""
 "Si está activado, el equipo se muestra sin los miembros y la descripción "
 "aparece cuando se le pasa el cursor por encima"
 
-#: api/models.py:1134
+#: api/models.py:1143
 msgid ""
 "If true, it will allows the instance to submit to the corresponding contest."
 msgstr ""
 
-#: api/models.py:1262 mog/templates/mog/contest/_coming_contests.html:10
+#: api/models.py:1271 mog/templates/mog/contest/_coming_contests.html:10
 #: mog/templates/mog/contest/_past_contests.html:10
 #: mog/templates/mog/contest/_running_contests.html:10
 #: mog/templates/mog/problem/index.html:32
 msgid "Contest"
 msgstr "Concurso"
 
-#: api/models.py:1270 mog/templates/mog/contest/problems.html:36
+#: api/models.py:1279 mog/templates/mog/contest/problems.html:36
 #: mog/templates/mog/submission/_list.html:11
 #: mog/templates/mog/submission/index.html:21
 #: mog/templates/mog/submit/submit.html:43
 msgid "Problem"
 msgstr "Problema"
 
-#: api/models.py:1285
+#: api/models.py:1294
 msgid "Public"
 msgstr "Público"
 
-#: api/models.py:1286 mog/forms.py:224
+#: api/models.py:1295 mog/forms.py:224
 #: mog/templates/mog/contest/clarifications.html:60
 msgid "Question"
 msgstr "Pregunta"
 
-#: api/models.py:1287 mog/forms.py:252
+#: api/models.py:1296 mog/forms.py:252
 #: mog/templates/mog/contest/clarifications.html:61
 #: mog/templates/mog/contest/clarifications.html:120
 msgid "Answer"
 msgstr "Respuesta"
 
-#: api/models.py:1311 mog/templates/mog/user/messages.html:22
+#: api/models.py:1320 mog/templates/mog/user/messages.html:22
 #: mog/templates/mog/user/messages.html:51
 msgid "Subject"
 msgstr "Asunto"
 
-#: api/models.py:1312
+#: api/models.py:1321
 #: mog/templates/mog/contest/_edit_instance_team_modal.html:19
 #: mog/templates/mog/user/_create_team.html:27
 #: mog/templates/mog/user/_edit_team.html:26
@@ -120,15 +120,15 @@ msgstr "Asunto"
 msgid "Description"
 msgstr "Descripción"
 
-#: api/models.py:1317
+#: api/models.py:1326
 msgid "Screenshot"
 msgstr "Captura de pantalla"
 
-#: judge/settings.py:212
+#: judge/settings.py:209
 msgid "Spanish"
 msgstr "Español"
 
-#: judge/settings.py:213
+#: judge/settings.py:210
 msgid "English"
 msgstr "Inglés"
 
@@ -205,7 +205,7 @@ msgstr "Inicio"
 
 #: mog/templates/mog/base.html:162 mog/templates/mog/contest/permission.html:62
 #: mog/templates/mog/contest/registration.html:48
-#: mog/templates/mog/institution/index.html:22
+#: mog/templates/mog/institution/index.html:27
 #: mog/templates/mog/user/index.html:12
 msgid "Users"
 msgstr "Usuarios"
@@ -285,7 +285,7 @@ msgstr "Patrocinado por"
 
 #: mog/templates/mog/checker/_actions.html:12
 #: mog/templates/mog/contest/_actions.html:12
-#: mog/templates/mog/institution/index.html:24
+#: mog/templates/mog/institution/index.html:33
 #: mog/templates/mog/user/teams.html:19
 msgid "Actions"
 msgstr "Acciones"
@@ -302,8 +302,8 @@ msgstr "Contenido"
 #: mog/templates/mog/comment/_edit_comment.html:25
 #: mog/templates/mog/comment/_remove_comment.html:23
 #: mog/templates/mog/contest/_left.html:306
-#: mog/templates/mog/institution/index.html:91
-#: mog/templates/mog/institution/index.html:138
+#: mog/templates/mog/institution/index.html:110
+#: mog/templates/mog/institution/index.html:159
 #: mog/templates/mog/problem/edit.html:28
 #: mog/templates/mog/user/_create_team.html:51
 #: mog/templates/mog/user/_edit_team.html:45
@@ -358,7 +358,7 @@ msgstr "Registro"
 #: mog/templates/mog/contest/_running_contests.html:14
 #: mog/templates/mog/contest/overview.html:88
 #: mog/templates/mog/contest/registration.html:77
-#: mog/templates/mog/institution/index.html:23
+#: mog/templates/mog/institution/index.html:30
 #: mog/templates/mog/user/detail.html:20 mog/templates/mog/user/profile.html:57
 msgid "Teams"
 msgstr "Equipos"
@@ -417,7 +417,7 @@ msgstr "Abierto"
 #: mog/templates/mog/contest/_unregister.html:21
 #: mog/templates/mog/contest/overview.html:92
 #: mog/templates/mog/contest/overview.html:104
-#: mog/templates/mog/problem/detail.html:200
+#: mog/templates/mog/problem/detail.html:206
 #: mog/templates/mog/user/_remove_team.html:22
 msgid "Yes"
 msgstr "Si"
@@ -430,7 +430,7 @@ msgstr "Si"
 #: mog/templates/mog/contest/_unregister.html:20
 #: mog/templates/mog/contest/overview.html:94
 #: mog/templates/mog/contest/overview.html:106
-#: mog/templates/mog/problem/detail.html:199
+#: mog/templates/mog/problem/detail.html:205
 #: mog/templates/mog/user/_remove_team.html:21
 msgid "No"
 msgstr "No"
@@ -964,52 +964,52 @@ msgstr "Instituciones"
 msgid "Create institution"
 msgstr "Crear institución"
 
-#: mog/templates/mog/institution/index.html:19
-#: mog/templates/mog/institution/index.html:120
+#: mog/templates/mog/institution/index.html:21
+#: mog/templates/mog/institution/index.html:141
 #: mog/templates/mog/user/_create_team.html:22
 #: mog/templates/mog/user/_edit_team.html:21
 msgid "Name"
 msgstr "Nombre"
 
-#: mog/templates/mog/institution/index.html:20
-#: mog/templates/mog/institution/index.html:124
+#: mog/templates/mog/institution/index.html:22
+#: mog/templates/mog/institution/index.html:145
 msgid "Website"
 msgstr "Sitio web"
 
-#: mog/templates/mog/institution/index.html:21
-#: mog/templates/mog/institution/index.html:128
+#: mog/templates/mog/institution/index.html:24
+#: mog/templates/mog/institution/index.html:149
 msgid "Country"
 msgstr "País"
 
-#: mog/templates/mog/institution/index.html:57
+#: mog/templates/mog/institution/index.html:71
 msgid "Cannot delete institution with users or teams"
 msgstr "No se puede eliminar institución con usuarios o equipos"
 
-#: mog/templates/mog/institution/index.html:62
+#: mog/templates/mog/institution/index.html:77
 msgid "Delete institution"
 msgstr "Eliminar institución"
 
-#: mog/templates/mog/institution/index.html:77
+#: mog/templates/mog/institution/index.html:95
 msgid "Delete Institution"
 msgstr "Eliminar Institución"
 
-#: mog/templates/mog/institution/index.html:81
+#: mog/templates/mog/institution/index.html:99
 msgid "Are you sure you want to delete the institution"
 msgstr "¿Estás seguro que deseas eliminar la institución"
 
-#: mog/templates/mog/institution/index.html:92
+#: mog/templates/mog/institution/index.html:111
 msgid "Delete"
 msgstr "Eliminar"
 
-#: mog/templates/mog/institution/index.html:102
+#: mog/templates/mog/institution/index.html:121
 msgid "No institutions to show!"
 msgstr "¡No hay instituciones para mostrar!"
 
-#: mog/templates/mog/institution/index.html:116
+#: mog/templates/mog/institution/index.html:137
 msgid "Create Institution"
 msgstr "Crear Institución"
 
-#: mog/templates/mog/institution/index.html:139
+#: mog/templates/mog/institution/index.html:160
 msgid "Create"
 msgstr "Crear"
 
@@ -1102,7 +1102,7 @@ msgid "Input"
 msgstr "Entrada"
 
 #: mog/templates/mog/problem/detail.html:116
-#: mog/templates/mog/problem/detail.html:146
+#: mog/templates/mog/problem/detail.html:149
 msgid "Output"
 msgstr "Salida"
 
@@ -1111,19 +1111,24 @@ msgid "Sample test(s)"
 msgstr "Caso(s) de ejemplo"
 
 #: mog/templates/mog/problem/detail.html:139
-#: mog/templates/mog/problem/detail.html:151
+#: mog/templates/mog/problem/detail.html:154
 msgid "Copy"
 msgstr "Copiar"
 
-#: mog/templates/mog/problem/detail.html:163
+#: mog/templates/mog/problem/detail.html:144
+#: mog/templates/mog/problem/detail.html:159
+msgid "Showing first 20 lines (click \"Copy\" to get full content)"
+msgstr "Mostrando las primeras 20 líneas (haz clic en \"Copiar\" para ver el contenido completo)"
+
+#: mog/templates/mog/problem/detail.html:169
 msgid "Hints"
 msgstr "Pistas"
 
-#: mog/templates/mog/problem/detail.html:184
+#: mog/templates/mog/problem/detail.html:190
 msgid "Delete Problem"
 msgstr "Eliminar problema"
 
-#: mog/templates/mog/problem/detail.html:189
+#: mog/templates/mog/problem/detail.html:195
 msgid ""
 "If you remove this problem all submissions related with it will be removed "
 "too."
@@ -1696,37 +1701,37 @@ msgstr "Se eliminó el registro satisfactoriamente!"
 msgid "Error enabling this user/team: "
 msgstr ""
 
-#: mog/views/institution.py:66
+#: mog/views/institution.py:70
 msgid "Name is required"
 msgstr "Nombre es requerido"
 
-#: mog/views/institution.py:74
+#: mog/views/institution.py:78
 msgid "Invalid country"
 msgstr "País inválido"
 
-#: mog/views/institution.py:82
+#: mog/views/institution.py:86
 msgid "Error creating institution: "
 msgstr "Error creando institución: "
 
-#: mog/views/institution.py:86
+#: mog/views/institution.py:90
 msgid "Institution created"
 msgstr "Institución creada"
 
-#: mog/views/institution.py:97
+#: mog/views/institution.py:101
 msgid "Institution not found"
 msgstr "Institución no encontrada"
 
-#: mog/views/institution.py:107
+#: mog/views/institution.py:112
 msgid "Cannot delete institution with users or teams. Users: {}, Teams: {}"
 msgstr ""
 "No se puede eliminar institución con usuarios o equipos. Usuarios: {}, "
 "Equipos: {}"
 
-#: mog/views/institution.py:114
+#: mog/views/institution.py:121
 msgid "Institution deleted successfully"
 msgstr "Institución eliminada exitosamente"
 
-#: mog/views/institution.py:116
+#: mog/views/institution.py:125
 msgid "Error deleting institution: "
 msgstr "Error eliminando institución: "
 

--- a/mog/static/mog/css/body.css
+++ b/mog/static/mog/css/body.css
@@ -48,6 +48,18 @@ textarea {
   padding: 0.25em;
   margin: 0;
   background-color: #efefef;
+  max-height: calc(1.4em * 20); /* 20 lines assuming 1.4em line-height */
+  line-height: 1.4em;
+  overflow: hidden;
+}
+
+.sample-test .overflow-message {
+  display: none;
+  text-align: center;
+}
+
+.has-overflow .overflow-message {
+  display: block;
 }
 
 .sample-tests {

--- a/mog/templates/mog/base.html
+++ b/mog/templates/mog/base.html
@@ -22,7 +22,7 @@
         <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="{% static 'mog/images/favicon.ico' %}"/>
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
-        <link href="{% static 'mog/css/body.css' %}?v=4.0" rel="stylesheet"/>
+        <link href="{% static 'mog/css/body.css' %}?v=5.0" rel="stylesheet"/>
 
         <!-- AddSense configuration -->
         <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>

--- a/mog/templates/mog/problem/detail.html
+++ b/mog/templates/mog/problem/detail.html
@@ -140,6 +140,9 @@
                                 </button>
                             </div>
                             <div class="pre"><span class="text">{{ si }}</span></div>
+                            <div class="overflow-message">
+                                --- {% trans 'Showing first 20 lines (click "Copy" to get full content)' %} ---
+                            </div>
                         </div>
                         <div class="output">
                             <div class="title test-case-header">
@@ -152,6 +155,9 @@
                                 </button>
                             </div>
                             <div class="pre"><span class="text">{{ so }}</span></div>
+                            <div class="overflow-message">
+                                --- {% trans 'Showing first 20 lines (click "Copy" to get full content)' %} ---
+                            </div>
                         </div>
                     </div>
                 {% endfor %}
@@ -217,6 +223,15 @@
                 el.innerText = el.innerText.replace('✓', '');
             }, 5000);
         }
+    </script>
+
+    <script>
+        document.querySelectorAll('.sample-test .input, .sample-test .output').forEach(container => {
+            const pre = container.querySelector('.text');
+            if (pre.textContent.split('\n').length > 20) {
+                container.classList.add('has-overflow');
+            }
+        });
     </script>
 
     {% include 'mog/includes/mathjax' %}


### PR DESCRIPTION
We're adding a problem to the qualifier with a
long sample test.

One option is to include a link for contestants to
download the test, but that adds extra work for
judges.

Another option is truncating and scrolling, but
users might not realize the sample is longer.

This PR truncates samples to 20 lines and shows
a ~warning indicating truncation. Users can click
the copy button to get the full content.

<img width="692" height="710" alt="image" src="https://github.com/user-attachments/assets/86125783-efca-45be-b844-5910a1702ff7" />

