### PR TITLE
🔒 create a dedicated user to run submissions

### DIFF
--- a/api/management/commands/__utils.py
+++ b/api/management/commands/__utils.py
@@ -3,8 +3,16 @@ import subprocess
 
 
 def get_exitcode_stdout_stderr(
-    cmd, cwd, env=None, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    cmd,
+    cwd,
+    env=None,
+    stdin=None,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    user=None,
 ):
+    if user:
+        cmd = f"su -s /bin/ash {user} -c " + shlex.quote(cmd)
     args = shlex.split(cmd)
     proc = subprocess.Popen(
         args, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd, env=env

--- a/docker/common/dockerfile.grader
+++ b/docker/common/dockerfile.grader
@@ -4,10 +4,15 @@ FROM alpine:3.15.0
 # layer, plus git python gcc and java
 RUN apk update && apk upgrade && apk add bash gcompat postgresql-dev git python3 python3-dev gcc g++ openjdk17-jdk iptables
 
-# Copy project content in the host machine into the container
-# as /code folder.
+# Copy project content from the host into the container as /code. Set
+# permissions to 750 so only root can read it. The 'judge' user should
+# not access content in this folder, especially settings.ini.
+#
+# NOTE: In development mode, we mount the volume over this workdir, so
+# permissions get overwritten. That's fine.
 WORKDIR /code
 COPY . /code/
+RUN chmod -R 750 /code
 
 # 0. Create a virtual environment and load it
 # 1. Install the build dependencies
@@ -61,3 +66,7 @@ RUN cd /opt && \
         tar xjvf pypy3.9-v7.3.10-linux64.tar.bz2 && \
         rm pypy3.9-v7.3.10-linux64.tar.bz2 && \
         mv pypy3.9-v7.3.10-linux64 pypy-7.3.10
+
+# 18. Create a user named judge to run submissions more securely.
+RUN addgroup -S judge && \
+	adduser -S -G judge judge -s /bin/bash


### PR DESCRIPTION
This PR creates a user named `judge` to run user
code with fewer privileges. For example, users
should not be able to read from the /problems or
/code folders.

Since /problems is a mounted folder, I manually
ran `chmod -R 750 /problems`.

### Before
<img width="1882" height="378" alt="image" src="https://github.com/user-attachments/assets/55e6b6c4-a1e1-44c1-8596-b3db9696a7cb" />


### After
<img width="1886" height="378" alt="image" src="https://github.com/user-attachments/assets/8afeacd8-cdc0-425a-a149-b4c9073766c2" />
