### PR TITLE
rename hints section into notes

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: django\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-04 05:16+0000\n"
+"POT-Creation-Date: 2025-10-04 05:55+0000\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1123,8 +1123,8 @@ msgstr ""
 "contenido completo)"
 
 #: mog/templates/mog/problem/detail.html:169
-msgid "Hints"
-msgstr "Pistas"
+msgid "Notes"
+msgstr "Notas"
 
 #: mog/templates/mog/problem/detail.html:190
 msgid "Delete Problem"
@@ -1771,6 +1771,9 @@ msgstr ""
 #: mog/views/submission.py:250
 msgid "Cannot rejudge submission: It is currently in grading process."
 msgstr ""
+
+#~ msgid "Hints"
+#~ msgstr "Pistas"
 
 #~ msgid "This action cannot be undone."
 #~ msgstr "Esta acción no se puede deshacer."

--- a/mog/templates/mog/problem/detail.html
+++ b/mog/templates/mog/problem/detail.html
@@ -166,7 +166,7 @@
 
         {% if problem.hints %}
             <div id="hints" class="col-md-12">
-                <h4 class="text-center">{% trans 'Hints' %}</h4>
+                <h4 class="text-center">{% trans 'Notes' %}</h4>
                 {% if problem.is_html %}
                 {{ problem.hints|safe }}
                 {% else %}


### PR DESCRIPTION
This seems more accurate since we're not really
providing help, just an observation. The field and a
few other references will still point to hints until we
refactor it, but users will see “Notes” on the problem
details page.