### PR TITLE
harden nginx and switch gunicorn to gevent workers

### DIFF
--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -13,7 +13,9 @@ services:
     build:
       context: ../..
       dockerfile: docker/prod/dockerfile
-    command: environ/bin/gunicorn --workers 4 --statsd-host=statsd_exporter:9125 --statsd-prefix=judge -b :8000 judge.wsgi:application
+    # --timeout 120: gevent worker heartbeat timeout. Must exceed nginx's proxy_read_timeout (90s)
+    # so nginx returns a 504 before gunicorn kills the worker.
+    command: environ/bin/gunicorn --workers 4 --worker-class gevent --worker-connections 1000 --timeout 120 --statsd-host=statsd_exporter:9125 --statsd-prefix=judge -b :8000 judge.wsgi:application
     volumes:
       - varwww:/var/www/judge
       - problems:/problems

--- a/docker/prod/matcomgrader.nginx.conf
+++ b/docker/prod/matcomgrader.nginx.conf
@@ -1,6 +1,50 @@
+# NOTE: limit_req_zone must live in the http{} block of your main nginx.conf,
+# not here. Add this line there:
+#
+#   limit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;
+#
+# This allocates a 10 MB shared-memory zone that tracks request rates per IP.
+
 server {
-    listen 80;
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/matcomgrader.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/matcomgrader.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
     server_name matcomgrader.com www.matcomgrader.com;
+
+    # --- Timeout hardening ---
+    # Cut off slow or dead clients before they tie up a Gunicorn worker.
+    # proxy_read_timeout should be slightly lower than Gunicorn's --timeout so
+    # Nginx returns a 504 before the worker is killed with SIGKILL.
+    client_body_timeout 10s;
+    client_header_timeout 10s;
+    proxy_connect_timeout 90s;
+    proxy_send_timeout 90s;
+    proxy_read_timeout 90s;
+
+    # --- Rate limiting ---
+    # Allow bursts of up to 100 requests; beyond that, return 429 immediately
+    # (nodelay means we don't queue excess requests, we reject them fast).
+    limit_req zone=mylimit burst=100 nodelay;
+
+    # --- Method and user-agent filtering ---
+    # Return 444 (connection closed, no response) for non-standard HTTP methods.
+    # This silently drops RDP probes, malformed HTTP, and most scanner noise.
+    if ($request_method !~ ^(GET|HEAD|POST|PUT|DELETE|OPTIONS|PATCH)$) {
+        return 444;
+    }
+
+    # Block well-known attack/scanning tools by User-Agent.
+    if ($http_user_agent ~* (DirBuster|sqlmap|nmap|nikto)) {
+        return 403;
+    }
+
+    # Block unwanted crawlers and bots.
+    if ($http_user_agent ~* (SemrushBot|MJ12bot|AhrefsBot|Amazonbot|ChatGPT-User|TikTokSpider|Sogou)) {
+        return 403;
+    }
 
     location / {
         proxy_pass http://localhost:8000; # Forward requests to Gunicorn on port 8000
@@ -8,6 +52,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # --- Request buffering ---
+        # Nginx buffers the full request body before forwarding it to Gunicorn.
+        # This means slow clients stall here, not inside a Gunicorn worker.
+        proxy_request_buffering on;
+        proxy_buffering on;
+        proxy_buffer_size 128k;
+        proxy_buffers 4 256k;
+        proxy_busy_buffers_size 256k;
     }
 
     location /prometheus/ {
@@ -27,21 +80,27 @@ server {
     # We need to grant permission to www-data for /var/lib/docker/; otherwise, nginx won't
     # be able to access the files. This is not ideal, and we should change it to containerize
     # nginx.
-    # sudo chown www-data:www-data    /var/lib/docker
-    # sudo chown www-data:www-data    /var/lib/docker/volumes
-    # sudo chown -R www-data:www-data /var/lib/docker/volumes/prod_varwww
+    # sudo chown -R www-data:www-data /var/lib/docker/volumes/prod_varwww/_data
     # (*) Check permissions with `sudo su -s /bin/bash www-data`
     location /static/ {
-        alias /var/lib/docker/volumes/prod_varwww/static/;
+        alias /var/lib/docker/volumes/prod_varwww/_data/static/;
         access_log off;
     }
 
     location /media/ {
-        alias /var/lib/docker/volumes/prod_varwww/media/;
+        alias /var/lib/docker/volumes/prod_varwww/_data/media/;
         access_log off;
     }
 
     # This should be limited to `/problem/test/\d+/list` URLs only, but for
     # some reason, I can't get it to work.
     client_max_body_size 50M;
+}
+
+
+# Redirect all HTTP traffic to HTTPS. managed by Certbot.
+server {
+    listen 80;
+    server_name matcomgrader.com www.matcomgrader.com;
+    return 301 https://$host$request_uri;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-ranged-response==0.2.0
 django-registration==2.5.2
 django-simple-captcha==0.5.10
 flake8==5.0.4
+gevent==24.2.1
 gunicorn==23.0.0
 html5lib==0.999999999
 humanize==0.5.1


### PR DESCRIPTION
We were spammed by RDP probes and slow-loris-style connections that
crashed Gunicorn workers (CRITICAL WORKER TIMEOUT / SIGKILL). This
commit addresses it at two layers:

Nginx (matcomgrader.nginx.conf):
- Enable HTTPS via Certbot (Let's Encrypt), redirect HTTP → HTTPS
- Buffer full request bodies so slow clients stall at Nginx, not inside
  a Gunicorn worker (proxy_request_buffering, proxy_buffers)
- Set aggressive timeouts: 10s for headers/body, 90s for proxy read
- Rate-limit to 10r/s per IP, burst 100 (limit_req_zone in http block)
- Drop non-standard HTTP methods with 444, block known scanner UAs

Gunicorn (docker-compose.yml):
- Switch to gevent worker class (--worker-class gevent) with 1000
  connections per worker, replacing one-connection-per-worker sync model
- Set --timeout 120 (above Nginx's 90s proxy_read_timeout) so Nginx
  returns a 504 before Gunicorn kills the worker
- Add gevent to requirements.txt