### PR TITLE
Support building the dev environment on arm64 (Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Matcom Online Grader (MOG) is a competitive programming platform designed for ho
 
 This will set up the development environment using Docker containers.
 
+#### Apple Silicon (arm64) Macs
+
+The grader image is x86_64-only (it bundles a custom gcc 11.3.0 toolchain), so it
+is built and run as `linux/amd64` under emulation. This requires:
+
+- **buildx** — `updev.sh` registers Homebrew's plugin automatically; install it
+  with `brew install docker-buildx` if it's missing.
+- **Rosetta emulation, not QEMU** — QEMU crashes the compiler. If you use
+  [Colima](https://github.com/abiosoft/colima), start it with Rosetta:
+
+  ```bash
+  colima start --vz-rosetta --cpu 4 --memory 6
+  ```
+
+  Docker Desktop users should enable *Settings → General → Use Rosetta for
+  x86/amd64 emulation*.
+
 ## Contributing
 
 We welcome contributions! Join our Discord community to discuss features, report bugs, or get help with development.

--- a/docker/common/dockerfile.grader
+++ b/docker/common/dockerfile.grader
@@ -1,4 +1,7 @@
-FROM alpine:3.15.0
+# This image installs an x86_64-only gcc 11.3.0 toolchain (plus PyPy/Mono), so
+# it must be built as linux/amd64. Pinning the platform here lets it build on
+# arm64 hosts (Apple Silicon) under emulation, matching the production arch.
+FROM --platform=linux/amd64 alpine:3.15.0
 
 # Update the system, and add bash and the glibc compatibility
 # layer, plus git python gcc and java

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   database:
     image: postgres:11.5
@@ -11,6 +9,13 @@ services:
       - pgdb:/var/lib/postgresql/data
     ports:
       - '5432:5432'
+    # Wait until Postgres actually accepts connections, not just until the
+    # container starts, so dependents don't race the database on startup.
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U judge -d judge']
+      interval: 3s
+      timeout: 3s
+      retries: 20
   api:
     build:
       context: ../..
@@ -27,8 +32,13 @@ services:
     ports:
       - '8000:8000'
     depends_on:
-      - database
+      database:
+        condition: service_healthy
   grader:
+    # The grader image installs an x86_64-only gcc toolchain (and PyPy/Mono),
+    # so it must be built and run as linux/amd64 to match production. On arm64
+    # hosts (Apple Silicon) this runs under emulation.
+    platform: linux/amd64
     build:
       context: ../..
       dockerfile: docker/common/dockerfile.grader
@@ -36,6 +46,9 @@ services:
     volumes:
       - ../..:/code
       - problems:/problems
+    depends_on:
+      database:
+        condition: service_healthy
     cap_add:
       - NET_ADMIN
     ulimits:

--- a/updev.sh
+++ b/updev.sh
@@ -5,5 +5,22 @@ fi
 
 database_pass=$(awk -F ":" '/DATABASE_PASS/ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}' settings.ini)
 
-DOCKER_BUILDKIT=0 DATABASE_PASS=$database_pass \
+# The grader image is x86_64-only (custom gcc 11.3.0 toolchain). On arm64 hosts
+# (Apple Silicon) it must be cross-built as linux/amd64 under emulation, which
+# requires BuildKit and the buildx plugin. Docker Desktop ships buildx; Homebrew
+# installs it but doesn't register it as a Docker CLI plugin, so wire it up here.
+if ! docker buildx version >/dev/null 2>&1; then
+  brew_buildx="$(brew --prefix 2>/dev/null)/lib/docker/cli-plugins/docker-buildx"
+  if [ -x "$brew_buildx" ]; then
+    echo "Registering Homebrew's buildx as a Docker CLI plugin..."
+    mkdir -p "$HOME/.docker/cli-plugins"
+    ln -sf "$brew_buildx" "$HOME/.docker/cli-plugins/docker-buildx"
+  else
+    echo "ERROR: 'docker buildx' is required to build the grader image (linux/amd64)." >&2
+    echo "Install it (macOS: 'brew install docker-buildx') or enable buildx in your Docker setup." >&2
+    exit 1
+  fi
+fi
+
+DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 DATABASE_PASS=$database_pass \
     docker-compose -f docker/dev/docker-compose.yml up


### PR DESCRIPTION
The grader image is x86_64-only, so build and run it as linux/amd64 under
emulation. Enable BuildKit + buildx (required for cross-arch builds) and add
a Postgres healthcheck so the app waits for the DB before migrating. Documents
the Rosetta requirement in the README.